### PR TITLE
Support chef-solo and/or reading users from an attribute.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,4 +33,13 @@ suites:
 - name: default
   run_list:
   - recipe[znc]
-  attributes: {}
+  attributes:
+    znc:
+      users:
+      - id: zeke
+        comment: Zeke Zeldman
+        znc:
+          pass: zeke123
+          ident: zman@example.com
+          alt_nick: zman
+          server: chat.freenode.net +7000

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['znc']['conf_dir']        = "#{znc['data_dir']}/configs"
 default['znc']['log_dir']         = "#{znc['data_dir']}/moddata/adminlog"
 default['znc']['module_dir']      = "#{znc['data_dir']}/modules"
 default['znc']['users_dir']       = "#{znc['data_dir']}/users"
+default['znc']['users']           = Chef::Config[:solo] ? [] : nil
 
 default['znc']['port']            = "+7777"
 default['znc']['skin']            = "dark-clouds"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ service "znc" do
   action [:enable, :start]
 end
 
-users = search(:users, 'groups:znc')
+users = node['znc']['users'] || search(:users, 'groups:znc') # ~FC003 alternative support for chef-solo
 
 # znc doesn't like to be automated...this prevents a race condition
 # http://wiki.znc.in/Configuration#Editing_config


### PR DESCRIPTION
A new attribute (`node['znc']['users']`) will be used if the cookbook is
converged with Chef Solo or if the attribute is set to a truthy value
such as an Array. Otherwise converging with Chef Client will still use
the search by default preserving previous behavior.
